### PR TITLE
stix2 3.0.1 ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:  
+  - https://staging.continuum.io/prefect/fs/stix2-patterns-feedstock/pr1/357cdb8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:  
-  - https://staging.continuum.io/prefect/fs/stix2-patterns-feedstock/pr1/357cdb8
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,6 @@ requirements:
   host:
     - pip
     - python
-    - pytz
-    - requests
-    - simplejson
-    - stix2-patterns >=1.2.0
     - wheel
     - setuptools
   run:
@@ -48,12 +44,13 @@ test:
     - stix2.v21
   requires:
     - pip
-    - coverage
     - pytest
-    - pytest-cov
+  #source_files:
+    # - stix2/test
   commands:
     - pip check
-    - python -m pytest --cov=stix2 stix2/test/ --cov-report term-missing -W ignore::stix2.exceptions.STIXDeprecationWarning
+    # - pytest stix2/test/ -v term-missing -W ignore::stix2.exceptions.STIXDeprecationWarning
+    # - pytest stix2/test/ -v --ignore=stix2/test/test_workbench.py --ignore=stix2/test/v20/test_bundle.py --ignore=stix2/test/v20/test_custom.py --ignore=stix2/test/v20/test_datastore_taxii.py --ignore=stix2/test/v20/test_malware.py --ignore=stix2/test/v20/test_object_markings.py --ignore=stix2/test/v20/test_observed_data.py  --ignore=stix2/test/v21/test_bundle.py --ignore=stix2/test/v21/test_custom.py --ignore=stix2/test/v21/test_datastore_taxii.py --ignore=stix2/test/v21/test_malware.py --ignore=stix2/test/v21/test_object_markings.py
 
 about:
   home: "https://oasis-open.github.io/cti-documentation/"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,18 +45,16 @@ test:
   requires:
     - pip
     - pytest
-  #source_files:
-    # - stix2/test
   commands:
     - pip check
-    # - pytest stix2/test/ -v term-missing -W ignore::stix2.exceptions.STIXDeprecationWarning
-    # - pytest stix2/test/ -v --ignore=stix2/test/test_workbench.py --ignore=stix2/test/v20/test_bundle.py --ignore=stix2/test/v20/test_custom.py --ignore=stix2/test/v20/test_datastore_taxii.py --ignore=stix2/test/v20/test_malware.py --ignore=stix2/test/v20/test_object_markings.py --ignore=stix2/test/v20/test_observed_data.py  --ignore=stix2/test/v21/test_bundle.py --ignore=stix2/test/v21/test_custom.py --ignore=stix2/test/v21/test_datastore_taxii.py --ignore=stix2/test/v21/test_malware.py --ignore=stix2/test/v21/test_object_markings.py
-
 about:
   home: "https://oasis-open.github.io/cti-documentation/"
-  license: BSD
+  description: |
+    Provides Python APIs for serializing and de-serializing STIX2 JSON content, along with higher-level APIs for common tasks, 
+    including data markings, versioning, and for resolving STIX IDs across multiple data sources.
+  license: BSD-3-Clause
   license_family: BSD
-  license_file: 
+  license_file: LICENSE
   summary: "Produce and consume STIX 2 JSON content"
   doc_url: https://stix2.readthedocs.io/en/latest/
   dev_url: https://github.com/oasis-open/cti-python-stix2/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,17 +48,17 @@ test:
   commands:
     - pip check
 about:
-  home: "https://oasis-open.github.io/cti-documentation/"
+  home: https://oasis-open.github.io/cti-documentation/
   description: |
     Provides Python APIs for serializing and de-serializing STIX2 JSON content, along with higher-level APIs for common tasks, 
     including data markings, versioning, and for resolving STIX IDs across multiple data sources.
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: "Produce and consume STIX 2 JSON content"
+  summary: Produce and consume STIX 2 JSON content
   doc_url: https://stix2.readthedocs.io/en/latest/
   dev_url: https://github.com/oasis-open/cti-python-stix2/
 
 extra:
   recipe-maintainers:
-    - your-github-id-here
+    - psteyer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - requests
     - simplejson
     - stix2-patterns >=1.2.0
+  run_constrained:
+    - taxii2-client >=2.3.0
 
 # Skipping tests that had relative imports and are not correctly run
 {% set tests_to_ignore = "" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,9 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 2a2718dc3451c84c709990b2ca220cc39c75ed23e0864d7e8d8190a9365b0cbf
+  # using github archive due to including tests
+  url: "https://github.com/oasis-open/cti-python-stix2/archive/refs/tags/v{{ version }}.tar.gz"
+  sha256: a6a20a36c211d84a992985e4496ee82e61f3608281f37e5381f833b6019355e3
 
 build:
   number: 0
@@ -27,6 +28,24 @@ requirements:
     - simplejson
     - stix2-patterns >=1.2.0
 
+# Skipping tests that had relative imports and are not correctly run
+{% set tests_to_ignore = "" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/test_workbench.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v20/test_bundle.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v20/test_custom.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v20/test_datastore_taxii.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v20/test_malware.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v20/test_object_markings.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v20/test_observed_data.py"%}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v21/test_bundle.py"%}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v21/test_custom.py"%}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v21/test_datastore_taxii.py"%}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v21/test_malware.py"%}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v21/test_object_markings.py"%}
+# Skipping test that requires missing test dependencies (taxii2-client, haversine, medallion)
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v20/test_environment.py"%}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=stix2/test/v21/test_environment.py"%}
+
 test:
   imports:
     - stix2
@@ -45,8 +64,13 @@ test:
   requires:
     - pip
     - pytest
+    - rapidfuzz
+  source_files:
+    - stix2/test
   commands:
     - pip check
+    - pytest stix2/test/ -v {{ tests_to_ignore }}
+
 about:
   home: https://oasis-open.github.io/cti-documentation/
   description: |
@@ -56,7 +80,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Produce and consume STIX 2 JSON content
-  doc_url: https://stix2.readthedocs.io/en/latest/
+  doc_url: https://stix2.readthedocs.io/
   dev_url: https://github.com/oasis-open/cti-python-stix2/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "stix2" %}
+{% set version = "3.0.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 2a2718dc3451c84c709990b2ca220cc39c75ed23e0864d7e8d8190a9365b0cbf
+
+build:
+  number: 0
+  skip: true  # [py>311]
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+
+requirements:
+  host:
+    - pip
+    - python
+    - pytz
+    - requests
+    - simplejson
+    - stix2-patterns >=1.2.0
+    - wheel
+    - setuptools
+  run:
+    - python
+    - pytz
+    - requests
+    - simplejson
+    - stix2-patterns >=1.2.0
+
+test:
+  imports:
+    - stix2
+    - stix2.canonicalization
+    - stix2.confidence
+    - stix2.datastore
+    - stix2.equivalence
+    - stix2.equivalence.graph
+    - stix2.equivalence.object
+    - stix2.equivalence.pattern
+    - stix2.equivalence.pattern.compare
+    - stix2.equivalence.pattern.transform
+    - stix2.markings
+    - stix2.v20
+    - stix2.v21
+  requires:
+    - pip
+    - coverage
+    - pytest
+    - pytest-cov
+  commands:
+    - pip check
+    - python -m pytest --cov=stix2 stix2/test/ --cov-report term-missing -W ignore::stix2.exceptions.STIXDeprecationWarning
+
+about:
+  home: "https://oasis-open.github.io/cti-documentation/"
+  license: BSD
+  license_family: BSD
+  license_file: 
+  summary: "Produce and consume STIX 2 JSON content"
+  doc_url: https://stix2.readthedocs.io/en/latest/
+  dev_url: https://github.com/oasis-open/cti-python-stix2/
+
+extra:
+  recipe-maintainers:
+    - your-github-id-here


### PR DESCRIPTION
stix2 3.0.1 ❄️ 

**Destination channel:** Snowflake

### Links

- [PKG-4121](https://anaconda.atlassian.net/browse/PKG-4121) 
- [Upstream repository](https://github.com/oasis-open/cti-python-stix2/)

### Explanation of changes:

- Initial package build
- added tests
- added ❄️ destination channel in abs


[PKG-4121]: https://anaconda.atlassian.net/browse/PKG-4121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ